### PR TITLE
Remove WaPo Preroll blocking

### DIFF
--- a/antipaywall.txt
+++ b/antipaywall.txt
@@ -94,8 +94,6 @@ theglobeandmail.com##+js(aopr, tgam.darwin.tests.segments.push)
 ||washingtonpost.com/wp-stat/pb/prod/pmbl.txt
 ||washingtonpost.com/pb/gr/c/default/*/identity-management-$script
 ||washingtonpost.com/pb/*/subscription-acquisition
-||d2p9l91d5g68ru.cloudfront.net/PrerollPlugin/
-washingtonpost.com##+js(set, $.prototype.wpPreroll, noopFunc)
 ||subscribe.washingtonpost.com^
 @@||subscribe.washingtonpost.com/user/$xhr,1p
 washingtonpost.com###leaderboard-wrapper


### PR DESCRIPTION
Blocking Preroll breaks games on the Washington Post website. Resolves #30