### PR TITLE
antipaywall.txt - fix typo

### DIFF
--- a/antipaywall.txt
+++ b/antipaywall.txt
@@ -349,4 +349,4 @@ wired.com##.journey-unit, [class*="ConsumerMarketingUnit"]
 ||axios.com/api/v1/licenses
 axios.com##[data-vars-experiment="pro-paywall"]
 axios.com##[class^="Modal_paywallContainer"]
-axios.com##html:style(overflow:inherit!important
+axios.com##html:style(overflow:inherit!important)


### PR DESCRIPTION
Fix missing parenthesis. Should fix that line which I think is currently ignored.