### PR TITLE
Update amazonannoyances.txt

### DIFF
--- a/amazonannoyances.txt
+++ b/amazonannoyances.txt
@@ -166,6 +166,7 @@
 /audible-seo-analytics/*
 ||audible.*/webplayer/*/logcounter
 ||audible.*/api/set-stat
+||live-video.net^
 
 ! Amazon element hiding
 
@@ -279,6 +280,7 @@ amazon.*##[name="goKindleStaticPopDiv"]
 amazon.*##[data-automation-id="top-banner-promo"]
 amazon.*##[data-automation-id="hero-quick-promo"]
 amazon.*##.olpMp3Slot
+amazon.*###live-flagship-root
 
 blog.aboutamazon.com##.PromoImage
 


### PR DESCRIPTION
There is a new section that I saw on the homepage for the first time the other day with livestreamed shopping, or something to that effect. I would definitely consider it an annoyance that should be blocked. It can also be blocked with: `amazon.*##.amazonlive-widget-padding` but `amazon.*###live-flagship-root` is the div while the `amazonlive-widget-padding` is the class. I also added in this a network rule `||live-video.net^` to just block loading of video from live-video.net so their shopping livestreams won't load.