### PR TITLE
Add ZVW Paywall Circumvention

### DIFF
--- a/antipaywall.txt
+++ b/antipaywall.txt
@@ -450,3 +450,6 @@ foxnews.com##.show-gate.gated-overlay.article-gating
 ||businessinsider.com/chunks/scripts/components~paywall-
 ||businessinsider.com/ajax/render-component?path=paywall
 
+!! (Germany) Zeitungsverlag Waiblingen
+www.zvw.de##.paywall:remove-class(paywall)
+www.zvw.de##.nfy-products-teaser


### PR DESCRIPTION
I'm not sure whether you take non-English paywall filters but I couldn't find any language specific alternative lists and yours seemed to be easy to contribute to :)

Blocks paywalls e.g. for https://www.zvw.de/rems-murr-kreis/eskalation-beim-afd-parteitag-interne-chats-der-afd-rems-murr-lassen-tief-blicken_arid-803173